### PR TITLE
fix: update dependencies to resolve security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,22 +30,22 @@
     <maven.compiler.source>17</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.main.basedir>${project.basedir}</project.main.basedir>
-    <spring-boot-dependencies.version>3.2.5</spring-boot-dependencies.version>
-    <jackson-bom.version>2.17.0</jackson-bom.version>
-    <netty-bom.version>4.1.115.Final</netty-bom.version>
-    <commons-codec.version>1.16.1</commons-codec.version>
-    <gson.version>2.10.1</gson.version>
+    <spring-boot-dependencies.version>3.5.3</spring-boot-dependencies.version>
+    <jackson-bom.version>2.19.2</jackson-bom.version>
+    <netty-bom.version>4.1.118.Final</netty-bom.version>
+    <commons-codec.version>1.18.0</commons-codec.version>
+    <gson.version>2.13.1</gson.version>
     <lombok.version>1.18.38</lombok.version>
-    <java-jwt.version>4.4.0</java-jwt.version>
+    <java-jwt.version>4.5.0</java-jwt.version>
     <jjwt.version>0.12.6</jjwt.version>
-    <lettuce.version>6.5.1.RELEASE</lettuce.version>
-    <guava.version>33.1.0-jre</guava.version>
-    <google-http-client.version>1.44.2</google-http-client.version>
-    <commons-lang3.version>3.14.0</commons-lang3.version>
+    <lettuce.version>6.7.1.RELEASE</lettuce.version>
+    <guava.version>33.4.8-jre</guava.version>
+    <google-http-client.version>1.47.1</google-http-client.version>
+    <commons-lang3.version>3.18.0</commons-lang3.version>
     <httpclient.version>4.5.14</httpclient.version>
     <httpclient-cache.version>4.5.14</httpclient-cache.version>
     <swagger-models.version>1.6.16</swagger-models.version>
-    <system-rules.version>1.18.0</system-rules.version>
+    <system-rules.version>1.19.0</system-rules.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
     <argLine>
@@ -146,7 +146,7 @@
     <dependency>
       <groupId>jakarta.validation</groupId>
       <artifactId>jakarta.validation-api</artifactId>
-      <version>3.1.0-M1</version>
+      <version>3.1.1</version>
     </dependency>
     <dependency>
       <groupId>jakarta.xml.bind</groupId>
@@ -156,7 +156,7 @@
     <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
-      <version>6.1.0-M1</version>
+      <version>6.1.0</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
Updates 13 Maven dependencies to resolve security vulnerabilities identified in issue #4.

## Critical Security Fixes
- Netty: 4.1.115.Final → 4.1.118.Final (CVE-2025-24970, CVE-2025-25193)
- Commons Lang3: 3.14.0 → 3.18.0 (CVE-2025-48924)

## Other Updates
- Spring Boot: 3.2.5 → 3.5.3
- Jackson: 2.17.0 → 2.19.2
- Jakarta APIs updated from milestone to stable releases
- Various other security and performance improvements

Resolves #4

Generated with [Claude Code](https://claude.ai/code)